### PR TITLE
Fix split container content overflow

### DIFF
--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -203,7 +203,7 @@ const SplitPanelContainer = styled('div')<{
 
   position: relative;
   display: grid;
-  overflow: auto;
+  overflow: hidden;
   grid-template-${p => p.orientation}: ${p => p.size} auto 1fr;
 
   &.disable-iframe-pointer iframe {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Prevents content overflow in `SplitPanelContainer` by changing its `overflow` property from `auto` to `hidden`.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-96d4fae1-3392-48f9-bae7-63002168710a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96d4fae1-3392-48f9-bae7-63002168710a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

